### PR TITLE
Uppercase

### DIFF
--- a/AnyDB/TablenamesMustBeUppercase.md
+++ b/AnyDB/TablenamesMustBeUppercase.md
@@ -34,7 +34,7 @@ Message:            Table names should be UPPERCASE
 | > | `liquibase checks copy --check-name=SqlUserDefinedPatternCheck` |
 | Give your check a short name for easier identification (up to 64 alpha-numeric characters only) [SqlUserDefinedPatternCheck1]: | `TableNamesMustBeUppercase` |
 | Set the Severity to return a code of 0-4 when triggered. (options: 'INFO'=0, 'MINOR'=1, 'MAJOR'=2, 'CRITICAL'=3, 'BLOCKER'=4)? [INFO]: | `<Choose a value: 0, 1, 2, 3, 4>` |
-| Set 'SEARCH_STRING' (options: a string, or a valid regular expression): | `(?im)create\s*(or\s*replace\s*|)table\s*((?-i).*[a-z].*)\s*\(` |
+| Set 'SEARCH_STRING' (options: a string, or a valid regular expression): | `(?im)create\s&ast;(or\s&ast;replace\s&ast;|)table\s&ast;((?-i).&ast;[a-z].&ast;)\s&ast;\(` |
 | Set 'MESSAGE' [A match for regular expression <SEARCH_STRING> was detected in Changeset <CHANGESET>.]: | `Table names should be UPPERCASE` |
 | Set 'STRIP_COMMENTS' (options: true, false) [true]: | `true` |
 

--- a/AnyDB/TablenamesMustBeUppercase.md
+++ b/AnyDB/TablenamesMustBeUppercase.md
@@ -34,7 +34,7 @@ Message:            Table names should be UPPERCASE
 | > | `liquibase checks copy --check-name=SqlUserDefinedPatternCheck` |
 | Give your check a short name for easier identification (up to 64 alpha-numeric characters only) [SqlUserDefinedPatternCheck1]: | `TableNamesMustBeUppercase` |
 | Set the Severity to return a code of 0-4 when triggered. (options: 'INFO'=0, 'MINOR'=1, 'MAJOR'=2, 'CRITICAL'=3, 'BLOCKER'=4)? [INFO]: | `<Choose a value: 0, 1, 2, 3, 4>` |
-| Set 'SEARCH_STRING' (options: a string, or a valid regular expression): | ```(?im)create\s*(or\s*replace\s*|)table\s*((?-i).*[a-z].*)\s*\(``` |
+| Set 'SEARCH_STRING' (options: a string, or a valid regular expression): | `(?im)create\s*(or\s*replace\s*|)table\s*((?-i).*[a-z].*)\s*\(` |
 | Set 'MESSAGE' [A match for regular expression <SEARCH_STRING> was detected in Changeset <CHANGESET>.]: | `Table names should be UPPERCASE` |
 | Set 'STRIP_COMMENTS' (options: true, false) [true]: | `true` |
 

--- a/AnyDB/TablenamesMustBeUppercase.md
+++ b/AnyDB/TablenamesMustBeUppercase.md
@@ -34,7 +34,7 @@ Message:            Table names should be UPPERCASE
 | > | `liquibase checks copy --check-name=SqlUserDefinedPatternCheck` |
 | Give your check a short name for easier identification (up to 64 alpha-numeric characters only) [SqlUserDefinedPatternCheck1]: | `TableNamesMustBeUppercase` |
 | Set the Severity to return a code of 0-4 when triggered. (options: 'INFO'=0, 'MINOR'=1, 'MAJOR'=2, 'CRITICAL'=3, 'BLOCKER'=4)? [INFO]: | `<Choose a value: 0, 1, 2, 3, 4>` |
-| Set 'SEARCH_STRING' (options: a string, or a valid regular expression): | `(?im)create\s*(or\s*replace\s*|)table\s*((?-i).*[a-z].*)\s*\(` |
+| Set 'SEARCH_STRING' (options: a string, or a valid regular expression): | ```(?im)create\s*(or\s*replace\s*|)table\s*((?-i).*[a-z].*)\s*\(``` |
 | Set 'MESSAGE' [A match for regular expression <SEARCH_STRING> was detected in Changeset <CHANGESET>.]: | `Table names should be UPPERCASE` |
 | Set 'STRIP_COMMENTS' (options: true, false) [true]: | `true` |
 

--- a/AnyDB/TablenamesMustBeUppercase.md
+++ b/AnyDB/TablenamesMustBeUppercase.md
@@ -34,7 +34,7 @@ Message:            Table names should be UPPERCASE
 | > | `liquibase checks copy --check-name=SqlUserDefinedPatternCheck` |
 | Give your check a short name for easier identification (up to 64 alpha-numeric characters only) [SqlUserDefinedPatternCheck1]: | `TableNamesMustBeUppercase` |
 | Set the Severity to return a code of 0-4 when triggered. (options: 'INFO'=0, 'MINOR'=1, 'MAJOR'=2, 'CRITICAL'=3, 'BLOCKER'=4)? [INFO]: | `<Choose a value: 0, 1, 2, 3, 4>` |
-| Set 'SEARCH_STRING' (options: a string, or a valid regular expression): | `(?im)create\s&ast;(or\s&ast;replace\s&ast;|)table\s&ast;((?-i).&ast;[a-z].&ast;)\s&ast;\(` |
+| Set 'SEARCH_STRING' (options: a string, or a valid regular expression): | `(?im)create\s$\times$(or\s$\times$replace\s$\times$|)table\s$\times$((?-i).$\times$[a-z].$\times$)\s$\times$\(` |
 | Set 'MESSAGE' [A match for regular expression <SEARCH_STRING> was detected in Changeset <CHANGESET>.]: | `Table names should be UPPERCASE` |
 | Set 'STRIP_COMMENTS' (options: true, false) [true]: | `true` |
 

--- a/AnyDB/TablenamesMustBeUppercase.md
+++ b/AnyDB/TablenamesMustBeUppercase.md
@@ -34,7 +34,7 @@ Message:            Table names should be UPPERCASE
 | > | `liquibase checks copy --check-name=SqlUserDefinedPatternCheck` |
 | Give your check a short name for easier identification (up to 64 alpha-numeric characters only) [SqlUserDefinedPatternCheck1]: | `TableNamesMustBeUppercase` |
 | Set the Severity to return a code of 0-4 when triggered. (options: 'INFO'=0, 'MINOR'=1, 'MAJOR'=2, 'CRITICAL'=3, 'BLOCKER'=4)? [INFO]: | `<Choose a value: 0, 1, 2, 3, 4>` |
-| Set 'SEARCH_STRING' (options: a string, or a valid regular expression): | `(?im)create\s\*(or\s\*replace\s\*|)table\s\*((?-i).\*[a-z].\*)\s\*\(` |
+| Set 'SEARCH_STRING' (options: a string, or a valid regular expression): | `(?im)create\s*(or\s*replace\s*|)table\s*((?-i).*[a-z].*)\s*\(` |
 | Set 'MESSAGE' [A match for regular expression <SEARCH_STRING> was detected in Changeset <CHANGESET>.]: | `Table names should be UPPERCASE` |
 | Set 'STRIP_COMMENTS' (options: true, false) [true]: | `true` |
 

--- a/AnyDB/TablenamesMustBeUppercase.md
+++ b/AnyDB/TablenamesMustBeUppercase.md
@@ -34,7 +34,7 @@ Message:            Table names should be UPPERCASE
 | > | `liquibase checks copy --check-name=SqlUserDefinedPatternCheck` |
 | Give your check a short name for easier identification (up to 64 alpha-numeric characters only) [SqlUserDefinedPatternCheck1]: | `TableNamesMustBeUppercase` |
 | Set the Severity to return a code of 0-4 when triggered. (options: 'INFO'=0, 'MINOR'=1, 'MAJOR'=2, 'CRITICAL'=3, 'BLOCKER'=4)? [INFO]: | `<Choose a value: 0, 1, 2, 3, 4>` |
-| Set 'SEARCH_STRING' (options: a string, or a valid regular expression): | `(?im)create\s$\times$(or\s$\times$replace\s$\times$|)table\s$\times$((?-i).$\times$[a-z].$\times$)\s$\times$\(` |
+| Set 'SEARCH_STRING' (options: a string, or a valid regular expression): | `(?im)create\s*(or\s*replace\s*|)table\s*((?-i).*[a-z].*)\s*\(` |
 | Set 'MESSAGE' [A match for regular expression <SEARCH_STRING> was detected in Changeset <CHANGESET>.]: | `Table names should be UPPERCASE` |
 | Set 'STRIP_COMMENTS' (options: true, false) [true]: | `true` |
 

--- a/AnyDB/TablenamesMustBeUppercase.md
+++ b/AnyDB/TablenamesMustBeUppercase.md
@@ -6,18 +6,26 @@ regex: `(?im)create\s*(or\s*replace\s*|)table\s*((?-i).*[a-z].*)\s*\(`
 
 # Sample Failing Scripts
 ``` sql
-create table dbo.SALES
+create table Sales (
+	id numeric not null 
+);
 ```
 ``` sql
-CREATE TABLE DBO.sales
+create table dbo.SALES (
+	id numeric not null 
+);
 ```
 ``` sql
-create table Sales
+create table DBO.sales (
+	id numeric not null 
+);
 ```
 
 # Sample Passing Scripts
 ``` sql
-create table DBO.SALES
+create table SALES (
+	id numeric not null 
+);
 ```
 
 # Sample Error Message

--- a/AnyDB/TablenamesMustBeUppercase.md
+++ b/AnyDB/TablenamesMustBeUppercase.md
@@ -34,7 +34,7 @@ Message:            Table names should be UPPERCASE
 | > | `liquibase checks copy --check-name=SqlUserDefinedPatternCheck` |
 | Give your check a short name for easier identification (up to 64 alpha-numeric characters only) [SqlUserDefinedPatternCheck1]: | `TableNamesMustBeUppercase` |
 | Set the Severity to return a code of 0-4 when triggered. (options: 'INFO'=0, 'MINOR'=1, 'MAJOR'=2, 'CRITICAL'=3, 'BLOCKER'=4)? [INFO]: | `<Choose a value: 0, 1, 2, 3, 4>` |
-| Set 'SEARCH_STRING' (options: a string, or a valid regular expression): | `(?im)create\s*(or\s*replace\s*|)table\s*((?-i).*[a-z].*)\s*\(` |
+| Set 'SEARCH_STRING' (options: a string, or a valid regular expression): | `(?im)create\s\*(or\s\*replace\s\*|)table\s\*((?-i).\*[a-z].\*)\s\*\(` |
 | Set 'MESSAGE' [A match for regular expression <SEARCH_STRING> was detected in Changeset <CHANGESET>.]: | `Table names should be UPPERCASE` |
 | Set 'STRIP_COMMENTS' (options: true, false) [true]: | `true` |
 

--- a/AnyDB/TablenamesMustBeUppercase.md
+++ b/AnyDB/TablenamesMustBeUppercase.md
@@ -15,6 +15,11 @@ CREATE TABLE DBO.sales
 create table Sales
 ```
 
+# Sample Passing Scripts
+``` sql
+create table DBO.SALES
+```
+
 # Sample Error Message
 ```
 CHANGELOG CHECKS
@@ -28,13 +33,11 @@ Check Severity:     MINOR (Return code: 1)
 Message:            Table names should be UPPERCASE
 ```
 # Step-by-Step
-
-| Prompt | Command or User Input |
-| ------ | ----------------------|
-| > | `liquibase checks copy --check-name=SqlUserDefinedPatternCheck` |
-| Give your check a short name for easier identification (up to 64 alpha-numeric characters only) [SqlUserDefinedPatternCheck1]: | `TableNamesMustBeUppercase` |
-| Set the Severity to return a code of 0-4 when triggered. (options: 'INFO'=0, 'MINOR'=1, 'MAJOR'=2, 'CRITICAL'=3, 'BLOCKER'=4)? [INFO]: | `<Choose a value: 0, 1, 2, 3, 4>` |
-| Set 'SEARCH_STRING' (options: a string, or a valid regular expression): | `(?im)create\s*(or\s*replace\s*|)table\s*((?-i).*[a-z].*)\s*\(` |
-| Set 'MESSAGE' [A match for regular expression <SEARCH_STRING> was detected in Changeset <CHANGESET>.]: | `Table names should be UPPERCASE` |
-| Set 'STRIP_COMMENTS' (options: true, false) [true]: | `true` |
-
+```
+Command: liquibase checks copy --check-name=SqlUserDefinedPatternCheck
+Short Name: TableNamesMustBeUppercase
+Severity: <Choose a value: 0, 1, 2, 3, 4>
+Search String: (?im)create\s*(or\s*replace\s*|)table\s*((?-i).*[a-z].*)\s*\(
+Message: Table names should be UPPERCASE
+Strip Comments: true
+```

--- a/AnyDB/TablenamesMustBeUppercase.md
+++ b/AnyDB/TablenamesMustBeUppercase.md
@@ -1,0 +1,40 @@
+# UppercaseTableNames
+
+Table names should be UPPERCASE
+
+regex: `(?im)create\s*(or\s*replace\s*|)table\s*((?-i).*[a-z].*)\s*\(`
+
+# Sample Failing Scripts
+``` sql
+create table dbo.SALES
+```
+``` sql
+CREATE TABLE DBO.sales
+```
+``` sql
+create table Sales
+```
+
+# Sample Error Message
+```
+CHANGELOG CHECKS
+----------------
+Checks completed validation of the changelog and found the following issues:
+
+Check Name:         Check for specific patterns in sql (TableNamesMustBeUppercase)
+Changeset ID:       01
+Changeset Filepath: Tables/SALES.sql
+Check Severity:     MINOR (Return code: 1)
+Message:            Table names should be UPPERCASE
+```
+# Step-by-Step
+
+| Prompt | Command or User Input |
+| ------ | ----------------------|
+| > | `liquibase checks copy --check-name=SqlUserDefinedPatternCheck` |
+| Give your check a short name for easier identification (up to 64 alpha-numeric characters only) [SqlUserDefinedPatternCheck1]: | `TableNamesMustBeUppercase` |
+| Set the Severity to return a code of 0-4 when triggered. (options: 'INFO'=0, 'MINOR'=1, 'MAJOR'=2, 'CRITICAL'=3, 'BLOCKER'=4)? [INFO]: | `<Choose a value: 0, 1, 2, 3, 4>` |
+| Set 'SEARCH_STRING' (options: a string, or a valid regular expression): | `(?im)create\s*(or\s*replace\s*|)table\s*((?-i).*[a-z].*)\s*\(` |
+| Set 'MESSAGE' [A match for regular expression <SEARCH_STRING> was detected in Changeset <CHANGESET>.]: | `Table names should be UPPERCASE` |
+| Set 'STRIP_COMMENTS' (options: true, false) [true]: | `true` |
+


### PR DESCRIPTION
I couldn't use the standard table format to show the step-by-step instructions because GitHub seems to have an issue with how the regex gets displayed - it keeps truncating the regex. Even though it would display correct in other markdown editors. I tried a few workarounds and nothing worked.